### PR TITLE
添加泛型支持

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,10 +5,10 @@ jobs:
     name: Test on Linux
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.18
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -18,10 +18,10 @@ jobs:
     name: Test on Mac
     runs-on: macos-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.18
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -31,10 +31,10 @@ jobs:
     name: Test on Windows
     runs-on: windows-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.18
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -1,0 +1,9 @@
+package demo
+
+func Add[T int | float64](i, j T) T {
+	return i + j
+}
+
+type S2[T int | float64] struct{ I T }
+
+func (s *S2[T]) Foo() T { return s.I }

--- a/examples/generic.go
+++ b/examples/generic.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/go-kiss/monkey"
+)
+
+func sum[T int | float64](a, b T) T {
+	return a + b
+}
+
+func foo[T int | float64](a, b T) T {
+	return a - b
+}
+
+type S1[T int | float64] struct {
+	i T
+}
+
+func (s *S1[T]) Get() T {
+	return s.i
+}
+
+type S1__monkey__[T int | float64] struct {
+	S1[T]
+}
+
+func (s *S1__monkey__[T]) Get() T {
+	return s.i + 1
+}
+
+func main() {
+	monkey.PatchRaw(sum[int], foo[int], false, true)
+	fmt.Println(sum(1, 2)) // display -1
+
+	monkey.PatchRaw((*S1[int]).Get, (*S1__monkey__[int]).Get, false, true)
+	s := S1[int]{i: 1}
+	fmt.Println(s.Get()) // display 2
+}

--- a/examples/instance_example.go
+++ b/examples/instance_example.go
@@ -10,9 +10,9 @@ import (
 )
 
 func main() {
-	monkey.PatchAll((*net.Dialer).DialContext, func(_ *net.Dialer, _ context.Context, _, _ string) (net.Conn, error) {
+	monkey.PatchRaw((*net.Dialer).DialContext, func(_ *net.Dialer, _ context.Context, _, _ string) (net.Conn, error) {
 		return nil, fmt.Errorf("no dialing allowed")
-	})
+	}, true, false)
 
 	_, err := http.Get("http://taoshu.in")
 	fmt.Println(err) // Get http://taoshu.in: no dialing allowed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kiss/monkey
 
-go 1.13
+go 1.18
 
 require (
 	github.com/huandu/go-tls v1.0.1


### PR DESCRIPTION
Go 在调用泛型函数的时候会为每一次的类型初始化生成不同的包装函数。
各包装函数会调用公共的底层函数。要想实现 mock，需要修改底层函数
代码段。

但是 Go 并没有提供获取底层函数指针的机制。目前的办法是遍历包装
函数代码段，找到第一个 CALL 指令。再根据 CALL 指令的参数计算底层
函数的位置。

因为支持泛型，所以 Go 最小支持版本为 1.18

https://taoshu.in/go/monkey/generic.html