### PR TITLE
重新支持全局打桩

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   test-linux:
     name: Test on Linux

--- a/README.md
+++ b/README.md
@@ -37,9 +37,18 @@ import (
 
 func sum(a, b int) int { return a + b }
 
+type S struct { i int }
+
+func (s *S) Get() int { return i }
+
 func main() {
+	// mock 普通函数
 	monkey.Patch(sum, func(a b int) int { return a - b })
 	fmt.Println(sum(1,2)) // 输出 -1
+	// mock 结构体方法
+	monkey.Patch((*s).Get, func(s *S) int { return -1 })
+	var s S
+	fmt.Println(s.Get()) // 输出 -1
 }
 ```
 

--- a/examples/instance_example.go
+++ b/examples/instance_example.go
@@ -1,19 +1,19 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
-	"reflect"
 
 	"github.com/go-kiss/monkey"
 )
 
 func main() {
-	var d *net.Dialer
-	monkey.PatchInstanceMethod(reflect.TypeOf(d), "Dial", func(_ *net.Dialer, _, _ string) (net.Conn, error) {
+	monkey.PatchAll((*net.Dialer).DialContext, func(_ *net.Dialer, _ context.Context, _, _ string) (net.Conn, error) {
 		return nil, fmt.Errorf("no dialing allowed")
 	})
-	_, err := http.Get("http://google.com")
-	fmt.Println(err) // Get http://google.com: no dialing allowed
+
+	_, err := http.Get("http://taoshu.in")
+	fmt.Println(err) // Get http://taoshu.in: no dialing allowed
 }

--- a/examples/no_http.go
+++ b/examples/no_http.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 
 	"github.com/go-kiss/monkey"
@@ -11,7 +10,7 @@ import (
 
 func main() {
 	var guard *monkey.PatchGuard
-	guard = monkey.PatchInstanceMethod(reflect.TypeOf(http.DefaultClient), "Get", func(c *http.Client, url string) (*http.Response, error) {
+	guard = monkey.Patch((*http.Client).Get, func(c *http.Client, url string) (*http.Response, error) {
 		guard.Unpatch()
 		defer guard.Restore()
 
@@ -22,8 +21,8 @@ func main() {
 		return c.Get(url)
 	})
 
-	_, err := http.Get("http://google.com")
+	_, err := http.Get("http://taoshu.in")
 	fmt.Println(err) // only https requests allowed
-	resp, err := http.Get("https://google.com")
+	resp, err := http.Get("https://taoshu.in")
 	fmt.Println(resp.Status, err) // 200 OK <nil>
 }

--- a/monkey_test.go
+++ b/monkey_test.go
@@ -88,7 +88,7 @@ func (f *f) No() bool { return false }
 func TestOnInstanceMethod(t *testing.T) {
 	i := &f{}
 	assert(t, !i.No())
-	monkey.PatchInstanceMethod(reflect.TypeOf(i), "No", func(_ *f) bool { return true })
+	monkey.Patch((*f).No, func(_ *f) bool { return true })
 	assert(t, i.No())
 	assert(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "No"))
 	assert(t, !i.No())
@@ -189,6 +189,18 @@ func TestG(t *testing.T) {
 		})
 		defer wg.Done()
 		assert(t, 2 == foo(1, 2))
+	}()
+	wg.Wait()
+}
+
+func TestGlobal(t *testing.T) {
+	monkey.PatchAll(foo, bar)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert(t, -1 == foo(1, 2))
 	}()
 	wg.Wait()
 }


### PR DESCRIPTION
本项目的亮点是分协程独立打桩。但今天发现一个必须使用全局打桩的场景。

Go 标准 http 客户端在发起请求的时候会调用底层的 Dialer 创建连接。
但创建连接的过程是在另外一个独立的协程执行的。如果只允许协程内打桩，
那就无法通过 mock Dialer 来改变 http 客户端的行为。

一种方式是 mock 更为上导致的 RoundTrip 对象。http 客户端对该对象的
操作是在同一个协程完成的。但作为通用库还是支持全局打桩比较好。

这次顺便移除了 PatchInstanceMethod 函数，其功能完全可以由 Patch 实现。