### PR TITLE
重构 Patch 传参方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ import (
 
 func sum(a, b int) int { return a + b }
 
+func sub1[T int|float64](a, b T) T { return a - b }
+func sub2[T int|float64](a, b T) T { return a + b }
+
 type S struct { i int }
 
 func (s *S) Get() int { return i }
@@ -44,7 +47,10 @@ func (s *S) Get() int { return i }
 func main() {
 	// mock 普通函数
 	monkey.Patch(sum, func(a b int) int { return a - b })
-	fmt.Println(sum(1,2)) // 输出 -1
+	fmt.Println(sum(1, 2)) // 输出 -1
+	// mock 泛型函数
+	monkey.Patch(sub1[int], sub2[int])
+	fmt.Println(sub1(1, 2)) // 输出 3
 	// mock 结构体方法
 	monkey.Patch((*s).Get, func(s *S) int { return -1 })
 	var s S

--- a/examples/generic.go
+++ b/examples/generic.go
@@ -31,10 +31,10 @@ func (s *S1__monkey__[T]) Get() T {
 }
 
 func main() {
-	monkey.PatchRaw(sum[int], foo[int], false, true)
+	monkey.Patch(sum[int], foo[int], monkey.OptGeneric)
 	fmt.Println(sum(1, 2)) // display -1
 
-	monkey.PatchRaw((*S1[int]).Get, (*S1__monkey__[int]).Get, false, true)
+	monkey.Patch((*S1[int]).Get, (*S1__monkey__[int]).Get, monkey.OptGeneric)
 	s := S1[int]{i: 1}
 	fmt.Println(s.Get()) // display 2
 }

--- a/examples/instance_example.go
+++ b/examples/instance_example.go
@@ -10,9 +10,9 @@ import (
 )
 
 func main() {
-	monkey.PatchRaw((*net.Dialer).DialContext, func(_ *net.Dialer, _ context.Context, _, _ string) (net.Conn, error) {
+	monkey.Patch((*net.Dialer).DialContext, func(_ *net.Dialer, _ context.Context, _, _ string) (net.Conn, error) {
 		return nil, fmt.Errorf("no dialing allowed")
-	}, true, false)
+	}, monkey.OptGlobal)
 
 	_, err := http.Get("http://taoshu.in")
 	fmt.Println(err) // Get http://taoshu.in: no dialing allowed

--- a/monkey.go
+++ b/monkey.go
@@ -37,22 +37,19 @@ func (g *PatchGuard) Restore() {
 // Usage examples:
 //   Patch(math.Abs, func(n float64) { return 0 })
 //   Patch((*net.Dialer).Dial, func(_ *net.Dialer, _, _ string) (net.Conn, error) {})
-func Patch(target, replacement interface{}) *PatchGuard {
+func Patch(target, replacement interface{}, opts ...Option) *PatchGuard {
 	t := reflect.ValueOf(target)
 	r := reflect.ValueOf(replacement)
 
-	patchValue(t, r, false, false)
+	o := opt{}
 
-	return &PatchGuard{t, r, false, false}
-}
+	for _, opt := range opts {
+		opt.apply(&o)
+	}
 
-func PatchRaw(target interface{}, replacement interface{}, global, generic bool) *PatchGuard {
-	t := reflect.ValueOf(target)
-	r := reflect.ValueOf(replacement)
+	patchValue(t, r, o.global, o.generic)
 
-	patchValue(t, r, global, generic)
-
-	return &PatchGuard{t, r, false, true}
+	return &PatchGuard{t, r, o.global, o.generic}
 }
 
 // See reflect.Value

--- a/monkey_test.go
+++ b/monkey_test.go
@@ -196,9 +196,9 @@ func TestG(t *testing.T) {
 }
 
 func TestGlobal(t *testing.T) {
-	monkey.PatchRaw(math.Abs, func(a float64) float64 {
+	monkey.Patch(math.Abs, func(a float64) float64 {
 		return a + 1
-	}, true, false)
+	}, monkey.OptGlobal)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -218,12 +218,12 @@ type S2__monkey__[T int | float64] struct{ demo.S2[T] }
 func (s *S2__monkey__[T]) Foo() T { return s.I * 2 }
 
 func TestGeneric(t *testing.T) {
-	g1 := monkey.PatchRaw(demo.Add[int], add2[int], false, true)
+	g1 := monkey.Patch(demo.Add[int], add2[int], monkey.OptGeneric)
 	assert(t, -1 == demo.Add(1, 2))
 	g1.Unpatch()
 	assert(t, 3 == demo.Add(1, 2))
 
-	g2 := monkey.PatchRaw((*demo.S2[int]).Foo, (*S2__monkey__[int]).Foo, false, true)
+	g2 := monkey.Patch((*demo.S2[int]).Foo, (*S2__monkey__[int]).Foo, monkey.OptGeneric)
 	s := demo.S2[int]{I: 2}
 	assert(t, 4 == s.Foo())
 	g2.Unpatch()

--- a/opts.go
+++ b/opts.go
@@ -1,0 +1,21 @@
+package monkey
+
+type Option interface {
+	apply(*opt)
+}
+
+var OptGlobal = optGlobal{}
+var OptGeneric = optGeneric{}
+
+type opt struct {
+	global  bool
+	generic bool
+}
+
+type optGlobal struct{}
+
+func (optGlobal) apply(o *opt) { o.global = true }
+
+type optGeneric struct{}
+
+func (optGeneric) apply(o *opt) { o.generic = true }


### PR DESCRIPTION
最早只有一个 global 参数，后面又添加了 generic 参数。为了方便使用，
之前还直接提供了 PatchGlobal 函数。但支持泛型之后，就会产生四种组合，
没办法再提供快捷函数，索性搞了一个 PatchRaw 函数，让大家随便传参。

但 PatchRaw 用起来非常麻烦，因为要为每一个参数都要提供对应的值，哪
怕不用也得传 fasle。这次通过引入 Option 接口来解决这个问题。

因为给 Patch 函数添加了变长 Option 类型的参数，使用者可以按需组合
不同的参数来控制 Patch 的行为。