### PR TITLE
修复 struct 传值导致泛型打桩卡住的问题

### DIFF
--- a/monkey_test.go
+++ b/monkey_test.go
@@ -229,3 +229,28 @@ func TestGeneric(t *testing.T) {
 	g2.Unpatch()
 	assert(t, 2 == s.Foo())
 }
+
+type TreeNode struct {
+	Name     string
+	ID       int
+	Children []*TreeNode
+	A        int
+	B        int
+	C        int
+	// 注释掉go test可以正常运行
+	A1 int
+	B2 int
+	C1 int
+}
+
+func first[T any](a, b T) T { return a }
+
+func second[T any](a, b T) T { return b }
+
+// https://github.com/go-kiss/monkey/issues/8
+func TestIssue8(t *testing.T) {
+	t1 := TreeNode{ID: 1}
+	t2 := TreeNode{ID: 2}
+	monkey.Patch(first[TreeNode], second[TreeNode], monkey.OptGeneric)
+	assert(t, t2.ID == first(t1, t2).ID)
+}


### PR DESCRIPTION
Fix #8

Go 会为泛型函数生成中间函数。但实际需要 mock 的是中间函数所
调用的公共函数。为此，我们需要遍历中间函数机器码，通过 CALL
指令确定公共函数的地址。

如果函数使用了 struct 值传递，Go 在一些场景下会插入若干额外
的 CALL 指令。这样 monkey 就会拿到错误的公共函数地址。

为此，我们需要跳过因为 struct 传值而需要执行的 CALL 指令。

通过观察生成的汇编代码，我发现这些 CALL 指令用 BP 寄存器，而
调用公共函数用的是 AX 寄存器。所以可以根据寄存器参数来过滤。