### PR TITLE
支持 go1.20 下泛型打桩

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,38 +5,38 @@ jobs:
     name: Test on Linux
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.18
+    - name: Set up Go 1.20
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.20
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
     - name: Test
-      run: go test -gcflags=-l
+      run: go test -gcflags='all=-N -l'
   test-macos:
     name: Test on Mac
     runs-on: macos-latest
     steps:
-    - name: Set up Go 1.18
+    - name: Set up Go 1.20
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.20
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
     - name: Test
-      run: go test -gcflags=-l
+      run: go test -gcflags='all=-N -l'
   test-windows:
     name: Test on Windows
     runs-on: windows-latest
     steps:
-    - name: Set up Go 1.18
+    - name: Set up Go 1.20
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.20
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
     - name: Test
-      run: go test -gcflags=-l
+      run: go test -gcflags='all=-N -l'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,42 +1,18 @@
 name: Go
 on: [pull_request]
 jobs:
-  test-linux:
-    name: Test on Linux
-    runs-on: ubuntu-latest
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        version: [1.18, 1.19, "1.20", 1.21]
+    runs-on: ${{ matrix.os }}
     steps:
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.20
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-    - name: Test
-      run: go test -gcflags='all=-N -l'
-  test-macos:
-    name: Test on Mac
-    runs-on: macos-latest
-    steps:
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.20
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-    - name: Test
-      run: go test -gcflags='all=-N -l'
-  test-windows:
-    name: Test on Windows
-    runs-on: windows-latest
-    steps:
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.20
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-    - name: Test
-      run: go test -gcflags='all=-N -l'
+      - name: Set up Go ${{ matrix.version }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.version }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Test
+        run: go test -gcflags='all=-N -l'

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Go 语言猴子补丁（monkey patching）框架。
 
 Bouke 已经不再维护原项目，所以只能开一个新项目了🤣。
 
-有兴趣的同学也可以加微信 `taoshu-in` 讨论，拉你进群。
-
 ## 快速入门
 
 首先，引入 monkey 包
@@ -62,7 +60,9 @@ func main() {
 
 ## 注意事项
 
-1. Monkey 需要关闭 Go 语言的内联优化才能生效，比如测试的时候需要：`go test -gcflags=all=-l`。
+1. Monkey 需要关闭 Go 语言的内联优化才能生效，比如测试的时候需要：`go test -gcflags='all=-N -l'`。
 2. Monkey 需要在运行的时候修改内存代码段，因而无法在一些对安全性要求比较高的系统上工作。
 3. Monkey 不应该用于生产系统，但用来 mock 测试代码还是没有问题的。
-4. Monkey 目前仅支持 amd64 指令架构，支持 linux/macos/windows 平台。
+4. Monkey 目前仅支持 amd64 指令架构，支持 linux/macos/~~windows~~[^win] 平台。
+
+[^win]: 目前在 Win 平台下 Go 1.20 版本之后会报错。欢迎熟悉 Win 平台的同学提供 PR。问题解决之前建议 Win 用户使用 WSL。

--- a/go.sum
+++ b/go.sum
@@ -3,4 +3,3 @@ github.com/huandu/go-tls v1.0.1/go.mod h1:WeItecBdaIdUBRb7cSMMk+rq41iFKhf6Q9mDRD
 golang.org/x/arch v0.0.0-20210901143047-ebb09ed340f1 h1:MwxAfiDvuwX8Nnnc6iRDhzyMyyc2tz5tYyCP/pZcPCg=
 golang.org/x/arch v0.0.0-20210901143047-ebb09ed340f1/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/sys v0.0.0-20200107162124-548cf772de50/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=


### PR DESCRIPTION
Go 调用泛型函数时会先执行 LEA 指令，再执行 CALL 指令。我在上次提交

1f9d72d787e9444e1c249acee84a2b31b5c10485

中基于此特点跳过了跟 struct 传值产生的 CALL 指令，修复了 struct 传值导致
泛型打桩卡住的问题。

判断的依据是看 CALL 指令前面是否还有 LEA 指令且第一个参数为 RAX。

根据 Ruomenger 的调查，Go1.20 在执行 LEA 指令时，其目的寄存器由 RAX
改为 RBX，从而导致泛型 mock 出错。我还没找到对应的改动以及改动的原因。

Ruomenger 提议在检查 LEA 指令时同时支持 RAX 和 RBX 两种情况。但我认为
这样做不能根除问题，以后 Go 编译器改版可能还会引出新问题。

经过一番研究，我感觉使用函数名来判断可能是一个比较稳定的的办法。
getFirstCallFunc 最终找到泛型底层函数的地址。该地址对应的函数名包含`[...]`：

```
github.com/go-kiss/monkey_test.add2[...]
github.com/go-kiss/monkey/demo.Add[...]
github.com/go-kiss/monkey_test.(*S2__monkey__[...]).Foo
github.com/go-kiss/monkey/demo.(*S2[...]).Foo
```

以此为基准来确定函数指针应该没问题。而且 Go 语言提供 runtime.FuncForPC 非常方便。

Fix #12