### PR TITLE
fix: 修复代码中的一些警告问题

### DIFF
--- a/monkey.go
+++ b/monkey.go
@@ -84,7 +84,7 @@ func checkStructMonkeyType(a, b reflect.Type) bool {
 	t1 := a.In(0).String()
 	t2 := b.In(0).String()
 
-	if strings.Index(t2, "__monkey__") == -1 {
+	if !strings.Contains(t2, "__monkey__") {
 		return false
 	}
 
@@ -158,12 +158,12 @@ func PatchEmpty(target interface{}) {
 
 	t := reflect.ValueOf(target).Pointer()
 
-	p, ok := patches[t]
+	_, ok := patches[t]
 	if ok {
 		return
 	}
 
-	p = &patch{from: t}
+	p := &patch{from: t}
 	patches[t] = p
 	p.Apply()
 }
@@ -205,10 +205,6 @@ func unpatchValue(target reflect.Value) bool {
 	}
 
 	return patch.Del()
-}
-
-func unpatch(target uintptr, p *patch) {
-	copyToLocation(target, p.original)
 }
 
 type patch struct {

--- a/monkey_test.go
+++ b/monkey_test.go
@@ -156,7 +156,7 @@ func TestEmpty(t *testing.T) {
 					}
 				}(j)
 				monkey.Patch(foo, f)
-				assert(t, 1+1+j == foo(1, 1))
+				assert(t, foo(1, 1) == 1+1+j)
 				monkey.Unpatch(foo)
 				select {
 				case <-stop:
@@ -169,7 +169,7 @@ func TestEmpty(t *testing.T) {
 	}
 
 	for i := 0; i < 2000000; i++ {
-		assert(t, i+1 == foo(i, 1))
+		assert(t, foo(i, 1) == i+1)
 	}
 	close(stop)
 	wg.Wait()
@@ -178,19 +178,19 @@ func TestEmpty(t *testing.T) {
 func TestG(t *testing.T) {
 	monkey.Patch(foo, bar)
 
-	assert(t, -1 == foo(1, 2))
+	assert(t, foo(1, 2) == -1)
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		assert(t, 3 == foo(1, 2))
+		assert(t, foo(1, 2) == 3)
 	}()
 	go func() {
 		monkey.Patch(foo, func(a, b int) int {
 			return a * b
 		})
 		defer wg.Done()
-		assert(t, 2 == foo(1, 2))
+		assert(t, foo(1, 2) == 2)
 	}()
 	wg.Wait()
 }
@@ -204,12 +204,12 @@ func TestGlobal(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert(t, 2 == math.Abs(1))
+		assert(t, math.Abs(1) == 2)
 	}()
 	wg.Wait()
 
 	g0.Unpatch()
-	assert(t, 1 == math.Abs(1))
+	assert(t, math.Abs(1) == 1)
 }
 
 func add2[T int | float64](i, j T) T {
@@ -222,15 +222,15 @@ func (s *S2__monkey__[T]) Foo() T { return s.I * 2 }
 
 func TestGeneric(t *testing.T) {
 	g1 := monkey.Patch(demo.Add[int], add2[int], monkey.OptGeneric)
-	assert(t, -1 == demo.Add(1, 2))
+	assert(t, demo.Add(1, 2) == -1)
 	g1.Unpatch()
-	assert(t, 3 == demo.Add(1, 2))
+	assert(t, demo.Add(1, 2) == 3)
 
 	g2 := monkey.Patch((*demo.S2[int]).Foo, (*S2__monkey__[int]).Foo, monkey.OptGeneric)
 	s := demo.S2[int]{I: 2}
-	assert(t, 4 == s.Foo())
+	assert(t, s.Foo() == 4)
 	g2.Unpatch()
-	assert(t, 2 == s.Foo())
+	assert(t, s.Foo() == 2)
 }
 
 type TreeNode struct {

--- a/replace.go
+++ b/replace.go
@@ -1,17 +1,12 @@
 package monkey
 
 import (
-	"reflect"
 	"syscall"
 	"unsafe"
 )
 
 func rawMemoryAccess(p uintptr, length int) []byte {
-	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: p,
-		Len:  length,
-		Cap:  length,
-	}))
+	return unsafe.Slice((*byte)(unsafe.Pointer(p)), length)
 }
 
 func pageStart(ptr uintptr) uintptr {


### PR DESCRIPTION
修复项目中的一些警告问题，主要有：

1. yoda conditions,go中不需要将常量放在等于判断的前部
2. 使用 strings.Contains 替换 strings.Index 判断子串是否存在
3. 使用 unsafe.Slice 替换 reflect.SliceHeader
4. 移除未使用的函数 unpatch
5. 获取 map 中的 value 后并未使用

![image](https://github.com/go-kiss/monkey/assets/23385044/66f67428-a5a6-4d83-99d7-b28a9c86d6d8)

@taoso  FYI