### PR TITLE
修复 Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        version: ["1.18", "1.19", "1.20", "1.21"]
+        os: [ubuntu-latest, macos-13, windows-latest]
+        version: ["1.18", "1.19", "1.20", "1.21", "1.22"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go ${{ matrix.version }}


### PR DESCRIPTION
macos-latest 改为 M1(ARM) 架构，本项目不支持。先改成 macos-13，
后续可能要去掉 mac。

另外加上 go1.22 测试。